### PR TITLE
Remove 'host=localhost' from psycopg2 connect string to force socket connection

### DIFF
--- a/dataprep/mergeRivers.py
+++ b/dataprep/mergeRivers.py
@@ -9,7 +9,7 @@ if one is present, or else the HUC8 from reachcode."""
 import psycopg2
 import time
 
-conn = psycopg2.connect("dbname=rivers host=localhost")
+conn = psycopg2.connect("dbname=rivers")
 conn.autocommit = True      # required for Postgres bug workaround below
 cur = conn.cursor()
 


### PR DESCRIPTION
When you specify a host, psycopg2 will connect to Postgres via a TCP connection (requires un/pw) but if you remove the hostname it uses a socket (passwordless) so it "just works" when run as root (with a standard pg_hba.conf).
